### PR TITLE
refactor(color): add descriptions to color palette

### DIFF
--- a/get-tailwind-colors.mjs
+++ b/get-tailwind-colors.mjs
@@ -1,7 +1,7 @@
 /**
- * Returns a color map, leveraging Tailwind's color palette.
+ * Returns a color map leveraging Tailwind's color palette.
  *
- * @file   This files defines the getTailwindColors and getTailwindCompatibleColors functions.
+ * @file   This file defines the getTailwindColors and getTailwindCompatibleColors functions.
  * @since  1.0.0
  */
 
@@ -10,35 +10,52 @@ import colors from 'tailwindcss/colors';
 /**
  * Returns the full color map including metadata like subtitles.
  *
+ * This is the Denali source of truth for colors. The color object below is used
+ * by Storybook to automatically generate a color palette preview along with titles
+ * and subtitles. It is also used by `getTailwindCompatibleColors()` to drop the
+ * desc value and import only the colors to the Tailwind config file.
+ *
  * @function
  * @returns {Object} The color map with metadata.
  */
 const getTailwindColors = () => ({
   brand: {
+    desc: 'Use for branding related content.',
     primary: colors.blue[600],
     secondary: colors.slate[600]
   },
+  canvas: {
+    desc: 'Use for backgrounds.',
+    light: '#fff',
+    medium: colors.slate[300],
+    dark: '#000'
+  },
   accent: {
-    'light-slate': colors.slate[200],
-    'medium-slate': colors.slate[400],
-    'dark-slate': colors.slate[600]
+    desc: 'Use for accents, like borders and shadows.',
+    light: colors.slate[200],
+    medium: colors.slate[400],
+    dark: colors.slate[900]
   },
   success: {
+    desc: 'Use for successful validation.',
     base: colors.green[700],
     focus: colors.green[800],
     action: colors.green[900]
   },
   danger: {
+    desc: 'Use for failed validation.',
     base: colors.red[600],
     focus: colors.red[700],
     action: colors.red[800]
   },
   warning: {
+    desc: 'Use for alerts and warnings.',
     base: colors.yellow[500],
     focus: colors.yellow[600],
     action: colors.yellow[700]
   },
   info: {
+    desc: 'Use for alerts and notifications.',
     base: colors.blue[600],
     focus: colors.blue[700],
     action: colors.blue[800]
@@ -46,3 +63,25 @@ const getTailwindColors = () => ({
 });
 
 export default getTailwindColors;
+
+/**
+ * Returns the Tailwind-compatible color map without metadata.
+ *
+ * @function
+ * @returns {Object} The color map for Tailwind.
+ */
+export const getTailwindCompatibleColors = () => {
+  const allColors = getTailwindColors();
+  const compatibleColors = {};
+
+  Object.keys(allColors).forEach((key) => {
+    compatibleColors[key] = {};
+    Object.keys(allColors[key]).forEach((subKey) => {
+      if (subKey !== 'desc') {
+        compatibleColors[key][subKey] = allColors[key][subKey];
+      }
+    });
+  });
+
+  return compatibleColors;
+};

--- a/src/stories/storybook-utilities/ColorPaletteStory.jsx
+++ b/src/stories/storybook-utilities/ColorPaletteStory.jsx
@@ -15,7 +15,10 @@ import getTailwindColors from '../../../get-tailwind-colors';
  * @returns {string} The title-cased string.
  */
 const toTitleCase = (str) => {
-  return str.replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
+  return str.replace(
+    /\w\S*/g,
+    (txt) => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()
+  );
 };
 
 /**
@@ -38,9 +41,12 @@ export const ColorPaletteStory = () => {
             <ColorItem
               key={status}
               title={toTitleCase(status)}
+              subtitle={groupedColors[status].desc}
               colors={Object.keys(statusColors).reduce((acc, key) => {
-                const kebabKey = `${status}-${key}`.toLowerCase();
-                acc[kebabKey] = statusColors[key];
+                if (key !== 'desc') {
+                  const kebabKey = `${status}-${key}`.toLowerCase();
+                  acc[kebabKey] = statusColors[key];
+                }
                 return acc;
               }, {})}
             />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-const getTailwindColors = require('./get-tailwind-colors.mjs');
+const getTailwindCompatibleColors = require('./get-tailwind-colors.mjs');
 
 export default {
   darkMode: 'class',
@@ -11,7 +11,7 @@ export default {
   ],
   theme: {
     extend: {
-      colors: getTailwindColors(),
+      colors: getTailwindCompatibleColors(),
       spacing: {
         1.75: ' 7px'
       }


### PR DESCRIPTION
Add a description to each color group in the color palette so that their suggested uses are made clear in Storybook.